### PR TITLE
Adding cost types ADD_KEY, CREATE_ACCOUNT and DEPLOY_CONTRACT

### DIFF
--- a/near-java-api-rpc/src/main/java/com/syntifi/near/api/rpc/model/transaction/CostType.java
+++ b/near-java-api-rpc/src/main/java/com/syntifi/near/api/rpc/model/transaction/CostType.java
@@ -8,11 +8,14 @@ package com.syntifi.near.api.rpc.model.transaction;
  * @since 0.0.1
  */
 public enum CostType {
+    ADD_KEY,
     BASE,
     CONTRACT_LOADING_BASE,
     CONTRACT_LOADING_BYTES,
     CONTRACT_COMPILE_BASE,
     CONTRACT_COMPILE_BYTES,
+    CREATE_ACCOUNT,
+    DEPLOY_CONTRACT,
     FUNCTION_CALL,
     LOG_BASE,
     LOG_BYTE,


### PR DESCRIPTION
Related with #15 

ADD_KEY is related with the action "add_full_access_key", CREATE_ACCOUNT with "create_account" and DEPLOY_CONTRACT with "deploy_contract"